### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/runbooks/runbook.md
+++ b/runbooks/runbook.md
@@ -2,14 +2,17 @@
     Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
     Any future edits should abide by this format.
 -->
-
 # upp-exports-rw-s3
 
 Application that performs CRUD operations on content and concept files and stores them in s3
 
+## Code
+
+upp-exports-rw-s3
+
 ## Primary URL
 
-<https://github.com/Financial-Times/upp-exports-rw-s3>
+https://github.com/Financial-Times/upp-exports-rw-s3
 
 ## Service Tier
 
@@ -18,23 +21,6 @@ Bronze
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- hristo.georgiev
-- elitsa.pavlova
-- elina.kaneva
-- ivan.nikolov
-- georgi.ivanov
-- robert.marinov
 
 ## Host Platform
 
@@ -45,9 +31,9 @@ AWS
 This is an API for reading/writing content and concepts payloads up to S3. The api specification can be found [here](https://docs.google.com/document/d/1Ck-o0Le9cXOfm-aVjiGmOT7ZTB5W5fDTsPqGkhzfa-U/edit#heading=h.jwsnnbv7enh5)
 The service is exposing following admin endpoints:
 
-- Healthchecks: <http://localhost:8080/__health>
-- Build Info: <http://localhost:8080/__build-info> or <http://localhost:8080/build-info>
-- GTG: <http://localhost:8080/__gtg>
+*   Healthchecks: <http://localhost:8080/__health>
+*   Build Info: <http://localhost:8080/__build-info> or <http://localhost:8080/build-info>
+*   GTG: <http://localhost:8080/__gtg>
 
 ## Contains Personal Data
 
@@ -56,6 +42,20 @@ No
 ## Contains Sensitive Data
 
 No
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -94,6 +94,14 @@ Manual
 
 The service is deployed with Jenkins job
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
 
 Manual
@@ -102,6 +110,10 @@ Manual
 
 To access the job clients need to provide basic auth credentials to log into the k8s clusters.
 To rotate credentials you need to login to a particular cluster and update varnish-auth secrets.
+
+## Monitoring
+
+<p><a href="https://upp-prod-delivery-eu.ft.com/__health/__pods-health?service-name=upp-exports-rw-s3" target="_blank">Prod-EU Health</a></p><p><a href="https://upp-prod-delivery-us.ft.com/__health/__pods-health?service-name=upp-exports-rw-s3" target="_blank">Prod-US Health</a><br><br></p>
 
 ## First Line Troubleshooting
 


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/upp-exports-rw-s3/blob/runbook-no-relationships-2021-03-19/runbooks/runbook.md) file has been automatically regenerated from the Biz Ops data for the **upp-exports-rw-s3** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **upp-exports-rw-s3** system in [Biz Ops](https://biz-ops.in.ft.com/System/upp-exports-rw-s3).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
